### PR TITLE
Dynamic config options for calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ In addition, the extension also attempts to hook into core grid listing customiz
 * [getAdditionalQueryStringForBuildAjaxListingLink](https://docs.preside.org/devguides/datamanager/customization/getAdditionalQueryStringForBuildAjaxListingLink.html)
 * [postFetchRecordsForGridListing](https://docs.preside.org/devguides/datamanager/customization/postFetchRecordsForGridListing.html)
 
+All [Full Calendar](https://fullcalendar.io/) configuration options can be passed in as dynamic values to the calendar initialisation.
+e.g. adding the month, agendaWeek and agendaDay views on the left side.
+
+```cfc
+objectCalendarView(
+	  objectName = "myPresideObject"
+	, args       = {
+		config = {
+			header = {
+				  left   = "month,agendaWeek,agendaDay"
+				, center = "title"
+				, right  = "today prev,next"
+			}
+		}
+	}
+)
+```
+
 ## Calendar event fields
 
 When returning an array of structs for the calendar, all the fields that are implemented by FullCalendar are supported. See docs for full details: https://fullcalendar.io/docs/event-object.

--- a/assets/js/admin/specific/calendarview/calendarView.js
+++ b/assets/js/admin/specific/calendarview/calendarView.js
@@ -7,9 +7,10 @@
 
 	$( '.calendar-view' ).each( function(){
 		var $calendarView = $( this )
-		  , sourceUrl     = $calendarView.data( "sourceUrl" )
-		  , aspectRatio   = $calendarView.data( "aspectRatio" ) || 2
-		  , $container    = $calendarView.closest( ".calendar-view-container" )
+		  , sourceUrl      = $calendarView.data( "sourceUrl" )
+		  , aspectRatio    = $calendarView.data( "aspectRatio" ) || 2
+		  , config         = cfrequest.calendarViewConfig        || {}
+		  , $container     = $calendarView.closest( ".calendar-view-container" )
 		  , $favouritesDiv = $container.find( ".calendar-view-favourites" )
 		  , fetchEvents, getAdditionalDataForAjaxFetch, getFavourites;
 
@@ -61,10 +62,10 @@
 			} );
 		}
 
-		$calendarView.fullCalendar({
-			  events      : fetchEvents
-			, eventRender : eventRenderer
-			, aspectRatio : aspectRatio
-		});
+		config.events      = fetchEvents;
+		config.eventRender = eventRenderer;
+		config.aspectRatio = aspectRatio;
+
+		$calendarView.fullCalendar(config);
 	} );
 } )( presideJQuery );

--- a/handlers/admin/CalendarView.cfc
+++ b/handlers/admin/CalendarView.cfc
@@ -10,7 +10,10 @@ component extends="preside.system.base.AdminHandler" {
 		var objectName = args.objectName ?: "";
 
 		event.include( "/js/admin/specific/calendarview/"  )
-		     .include( "/css/admin/specific/calendarview/" );
+		     .include( "/css/admin/specific/calendarview/" )
+		     .includeData({
+		     	calendarViewConfig = args.config ?: {}
+		     });
 
 		args.eventsSourceUrl = customizationService.runCustomization(
 			  objectName     = objectName


### PR DESCRIPTION
It is now possible to pass in dynamic options to the full calendar init.
Example (customising toolbar to be able to show day, week and month views):

`objectCalendarView(
	  objectName = "event"
	, args       = {
		config = {
			header = {
				  left   = "month,agendaWeek,agendaDay"
				, center = "title"
				, right  = "today prev,next"
			}
			, views = {
				week = {
				          titleFormat                = "[Week from] D MMMM YYYY"
					, titleRangeSeparator = " to "
				}
			}
		}
	}
);`